### PR TITLE
Add steps page to vite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,13 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import tailwindcss from '@tailwindcss/vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import lightningcss from 'vite-plugin-lightningcss'
 import browserslist from 'browserslist'
 import { browserslistToTargets } from 'lightningcss'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
     plugins: [
@@ -25,6 +29,14 @@ export default defineConfig({
         cssMinify: 'lightningcss',
         cssCodeSplit: true,
         minify: true,
+        rollupOptions: {
+            // Specify all pages as per https://vite.dev/guide/build#multi-page-app
+            input: {
+                index: resolve(__dirname, 'index.html'),
+                steps: resolve(__dirname, 'steps.html'),
+          },
+    },
+
     },
     css: {
         transformer: 'lightningcss',


### PR DESCRIPTION
Adds the `steps.html` page to the vite config as per https://vite.dev/guide/build#multi-page-app
No more 404!